### PR TITLE
fix: correct TokenWrapperAccount docs and error message

### DIFF
--- a/miden/src/accounts/token_wrapper.rs
+++ b/miden/src/accounts/token_wrapper.rs
@@ -34,7 +34,7 @@ impl TokenWrapperAccount {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [`BasicFungibleFaucet`] component from the given pieces of metadata.
+    /// Creates a new [`TokenWrapperAccount`] component with the given origin network and address.
     pub fn new(origin_network: u64, origin_address: [Felt; 3]) -> Self {
         Self { origin_network, origin_address }
     }
@@ -51,7 +51,7 @@ impl From<TokenWrapperAccount> for AccountComponent {
                     faucet.origin_address[1],
                     faucet.origin_address[0],
                 ]))
-            ]).expect("basic fungible faucet component should satisfy the requirements of a valid account component")
+            ]).expect("token wrapper account component should satisfy the requirements of a valid account component")
                 .with_supported_type(AccountType::FungibleFaucet)
     }
 }


### PR DESCRIPTION
Updated the TokenWrapperAccount::new doc comment to describe the actual component and its origin metadata instead of incorrectly referencing BasicFungibleFaucet. Adjusted the expect message in the From for AccountComponent implementation so that it refers to the token wrapper account component